### PR TITLE
Fix bind clash with Livewire

### DIFF
--- a/resources/js/chart.js
+++ b/resources/js/chart.js
@@ -27,21 +27,16 @@ export default () => {
             });
         },
 
-        exportChart: {
-            ['@export-chart.document'](event) {
-                const chart = getChart(this.$refs.container.id);
+        exportChart({detail: {chartId, type, exportSettings = {}, options = {}}}) {
+            const chart = getChart(this.$refs.container.id);
 
-                if (chart.renderTo.id !== event.detail.chartId) {
-                    return;
-                }
+            if (chart.renderTo.id !== chartId) {
+                return;
+            }
 
-                const exportSettings = event.detail.exportSettings || {};
-                exportSettings.type = event.detail.type;
+            exportSettings.type = type;
 
-                const chartOptions = event.detail.options || {};
-
-                chart.exportChartLocal(exportSettings, chartOptions);
-            },
+            chart.exportChartLocal(exportSettings, options);
         },
 
         initChart() {

--- a/resources/views/components/chart.blade.php
+++ b/resources/views/components/chart.blade.php
@@ -2,6 +2,6 @@
 <figure {{ $attributes->class('chart')->merge([
     'x-data' => 'highchartsChart',
 ]) }}>
-    <div class="chart-container" id="{{ $chartKey }}" wire:ignore x-bind="exportData" x-ref="container"></div>
+    <div class="chart-container" id="{{ $chartKey }}" x-on:export-chart.document="exportChart" x-ref="container"></div>
     {{ $slot }}
 </figure>


### PR DESCRIPTION
This PR fixes a clash with how Livewire tries to load x-bind, and replaces the x-bind call with a more explicit x-on:EVENT call.